### PR TITLE
Add functility to pass variables between dep and tests

### DIFF
--- a/agent_func.py
+++ b/agent_func.py
@@ -2,7 +2,6 @@ import inspect
 import re
 import textwrap
 import os
-import sys
 import json
 import time
 import random
@@ -12,6 +11,7 @@ import functools
 import sys
 import ba_ws_sdk.streaming as streaming
 import ba_ws_sdk.file_system as file_system
+import ba_ws_sdk.variables as variables
 from testui.support.testui_driver import TestUIDriver
 
 DEFAULT_TIMEOUT = int(os.getenv("DEFAULT_TIMEOUT", "10"))
@@ -248,6 +248,7 @@ def create_driver(_run_test_id='1'):
     """
     global driver, test_variables
     test_variables[_run_test_id] = {}
+    variables.init_run(_run_test_id)
     from selenium.webdriver.chrome.options import Options
     from testui.support.appium_driver import NewDriver
     options = Options()
@@ -342,34 +343,21 @@ def _generate_from_regex(pattern):
     return ''.join(out)
 
 
-def set_variable(name, value='', _run_test_id='1', regex_const=''):
+def set_variable(name: str, value: str = '', _run_test_id: str = '1', regex_const: str = '') -> str:
     """
-    Set a variable for the running test.
-
-    Usage:
-        set_variable({'name': 'username', 'value': 'alice'})
-        set_variable({'name': 'token', 'regex_const': '[A-Z]{3}\\d{4}'})
-
-    - name: variable name (str)
-    - value: explicit value; if provided, it's stored as-is
-    - regex_const: optional simple regex-like construction to generate a random value. You can construct it like:
-        supporting ONLY \\d, \\w, ., [a-z], and {n} quantifier.
+    Set a named variable for this test run. Supports regex_const for random value generation.
+    Values are stored both locally (for use_vars resolution) and in the SDK (for cross-test passing).
     """
     global test_variables
     if _run_test_id not in test_variables:
         test_variables[_run_test_id] = {}
 
-    if value != '':
-        test_variables[_run_test_id][name] = value
-        return test_variables[_run_test_id][name]
-
     if regex_const:
-        generated = _generate_from_regex(regex_const)
-        test_variables[_run_test_id][name] = generated
-        return generated
+        value = _generate_from_regex(regex_const)
 
-    test_variables[_run_test_id][name] = ''
-    return ''
+    test_variables[_run_test_id][name] = value
+    variables.set_variable(name, value, _run_test_id)
+    return value
 
 
 def stop_driver(_run_test_id='1'):
@@ -389,10 +377,36 @@ def stop_driver(_run_test_id='1'):
             file_system.clear_downloads(_run_test_id)
         except Exception:
             pass
+        variables.export_run(_run_test_id)
+        variables.cleanup_run(_run_test_id)
         driver[_run_test_id].quit()
         log_function_definition(stop_driver, _run_test_id=_run_test_id)
         return "success"
     return "no driver"
+
+
+def return_variable(name: str, _run_test_id: str = "1") -> str:
+    """
+    Retrieve a named variable set earlier in this run or imported from
+    a dependency test.
+    """
+    return variables.return_variable(name, _run_test_id)
+
+
+def get_exported_variables(_run_test_id: str = "1") -> dict:
+    """
+    Return all variables set during this run. Called by the backend after
+    test completion to capture variables for dependent tests.
+    """
+    return variables.get_exported_variables(_run_test_id)
+
+
+def import_variables(variables_dict: dict, _run_test_id: str = "1") -> str:
+    """
+    Pre-populate variables exported by a dependency test.
+    Called as a preamble before the dependent test's own steps.
+    """
+    return variables.import_variables(variables_dict, _run_test_id)
 
 
 def maximize_window(_run_test_id='1'):

--- a/system_prompt.txt
+++ b/system_prompt.txt
@@ -117,6 +117,29 @@ Your reasoning process follows these guidelines:
 
 ---
 
+11. **Passing Variables Between Tests**
+
+   Tests can depend on other tests. When a test runs as a dependency (its steps are replayed before the current test's own steps), any values it saved via `set_variable` are automatically available in the dependent test via `return_variable`.
+
+   **Rules:**
+   - **Call `set_variable` only for values that came directly from page content** (e.g. a badge count, an ID shown on screen) or that you randomly generated (e.g. via regex_const). Do NOT save URLs, credentials, or any value you fetched on your own initiative without the user asking.
+   - **Use descriptive names** so dependent tests can find the variable without guessing: e.g. `cart_badge_count`, `created_user_id`, `generated_otp`.
+   - **In a dependent test**, always try `return_variable(name)` first before re-fetching the value from the page. Only fall back to the page if the variable is genuinely not available.
+
+   **Example — dependency test saves a value:**
+   ```
+   click("css=.add-to-cart")
+   get_page_html()                          → badge shows "3"
+   set_variable("cart_badge_count", "3")    → save for dependent tests
+   stop_driver()
+   ```
+
+   **Example — dependent test retrieves it:**
+   ```
+   return_variable("cart_badge_count")      → returns "3"
+   exists_with_text("3")                    → verifies count matches
+   ```
+
 **User's request**:
 {{ user_message }}
 


### PR DESCRIPTION
To work, all four PR's attached to Jira Ticket should be applied

To test:
Dependency test:

Go to https://practice.expandtesting.com/register, register a new account with a randomly generated username and password Test1234!, assert the registration success message appears.

* set_variable should appear in thinking process

Test with dependency:

Go to https://practice.expandtesting.com/login, log in with the same account from Test 1, assert the dashboard loads successfully.

* Thinking process should include:
return_variable should appear in thinking process